### PR TITLE
Generated h2 and h3 headings for MusicXML reference tree view to feed…

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1876,6 +1876,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4893,6 +4894,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5541,6 +5543,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/docs/src/assets/icons/link-square-01-twotone-rounded.svg
+++ b/docs/src/assets/icons/link-square-01-twotone-rounded.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" color="currentColor" fill="none">
+    <path d="M11.1002 3C7.45057 3.00657 5.53942 3.09617 4.31806 4.31754C3 5.63559 3 7.75698 3 11.9997C3 16.2425 3 18.3639 4.31806 19.6819C5.63611 21 7.7575 21 12.0003 21C16.243 21 18.3644 21 19.6825 19.6819C20.9038 18.4606 20.9934 16.5494 21 12.8998" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <path opacity="0.4" d="M20.5532 3.44415L15.0039 8.97814M20.5532 3.44415C20.0592 2.94964 16.7316 2.99573 16.0281 3.00574M20.5532 3.44415C21.0471 3.93866 21.0011 7.26992 20.9911 7.97418" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/docs/src/components/ElementLink.astro
+++ b/docs/src/components/ElementLink.astro
@@ -4,4 +4,4 @@ import elementName from '../utils/ElementName';
 const { tag, schema } = Astro.props;
 const href = `/musicxml/${schema}-reference/elements/${tag}/`;
 ---
-<a href={href}>{elementName(tag)}</a>
+<a id={ tag } href={ href }>{ elementName(tag) }</a>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -17,6 +17,4 @@ import MenuIcon from '@icons/menu-02-stroke-standard.svg';
     <div>{ siteInfo.title } { siteInfo.specVersion } { siteInfo.isDraft && 'Draft' }</div>
   </a>
 
-  {siteInfo.isDev && <a class="absolute right translate-x-1/2" href={`https://w3c-cg.github.io${Astro.url.pathname}`} target="w3c-cg.github.io">See this page on the production site</a>}
-
 </header>

--- a/docs/src/components/SiteNav.astro
+++ b/docs/src/components/SiteNav.astro
@@ -1,12 +1,24 @@
 ---
 import { siteInfo } from '../site.config';
 import CGLogo from '@assets/img/logos/w3cg.svg';
+import LinkIcon from '@assets/icons/link-square-01-twotone-rounded.svg';
 
 const reportStatus = `${ siteInfo.isDraft ? 'Draft' : 'Final' } Report`;
 ---
 
 <div id="site-nav" class="fixed top-0 h-full px-10 border-r border-neutral-300 flex flex-col bg-olive-100 -translate-x-full lg:translate-x-0 transition-transform duration-400">
 	<nav class="overflow-y-auto scrollbar-hidden pt-32 pb-24">
+		{ 
+			siteInfo.isDev && 
+				<a 
+				  class="flex items-center justify-center text-sm absolute w-full top-14 left-0 py-1.5 bg-olive-100/80 backdrop-blur border-b border-neutral-300"
+					href={`https://w3c-cg.github.io${Astro.url.pathname}`}
+					target="w3c-cg.github.io"
+					>
+					<span>View page on production site</span>
+					<LinkIcon class="ml-2 w-4" />
+				</a>
+		}
 		<a href="/musicxml/" class="flex items-center mb-8 no-underline">
 			<CGLogo class="w-16 h-16" />
 			<p class="font-bold text-base w-24 leading-6">{ reportStatus }</p>

--- a/docs/src/pages/musicxml-reference/element-tree/index.astro
+++ b/docs/src/pages/musicxml-reference/element-tree/index.astro
@@ -1,18 +1,37 @@
 ---
 import { getCollection } from 'astro:content';
-
 import BaseLayout from '../../../layouts/Base.astro';
 import SchemaView from '@components/SchemaView.astro';
 import TreeElement from '@components/TreeElement.astro';
+import type { map } from 'astro:schema';
 
-const elements = await getCollection('musicxmlElementsTree');
+const elements = (await getCollection('musicxmlElementsTree')).sort((a,b) => a.id.localeCompare(b.id));
+
+// Extract the h2 and h3 headings needed for the PageNav component.
+const headings : object[] = [];
+elements.forEach(element => {
+  headings.push({
+    depth: 2,
+    slug: element.id,
+    text: element.id
+  });
+  const children = Object.keys(element.data).sort();
+  children.forEach(child => {
+    headings.push({
+      depth: 3,
+      slug: child,
+      text: child
+    });
+  });
+});
+
 const frontmatter = {
   title: 'Elements used in MusicXML'
 }
 ---
-<BaseLayout frontmatter={frontmatter}>
+<BaseLayout frontmatter={ frontmatter } headings={ headings }>
   <SchemaView schema="musicxml" current="tree"/>
   <ul>
-    {elements.sort((a,b) => a.id.localeCompare(b.id)).map(element => <li><TreeElement level={2} tag={element.id} children={element.data} schema="musicxml" /></li>)}
+    {elements.map(element => <li><TreeElement level={2} tag={element.id} children={element.data} schema="musicxml" /></li>)}
   </ul>
 </BaseLayout>


### PR DESCRIPTION
- Modified the ElementLink component to add link ids and the index page of the MusicXML tree view to generate a list of h2 and h3 headings to pass to the PageNav component.
- Redesigned and relocated the dev-only link to the production site.